### PR TITLE
Raise SymbolsError if symbol is not present

### DIFF
--- a/pymarketstore/exceptions.py
+++ b/pymarketstore/exceptions.py
@@ -1,0 +1,3 @@
+
+class SymbolsError(KeyError):
+    pass

--- a/pymarketstore/jsonrpc.py
+++ b/pymarketstore/jsonrpc.py
@@ -1,6 +1,7 @@
 import json
 import msgpack
 import requests
+from .exceptions import SymbolsError
 
 
 class JsonRpcClient(object):
@@ -42,6 +43,9 @@ class JsonRpcClient(object):
 
         if 'error' not in resp:
             raise Exception('invalid JSON-RPC protocol: missing error')
+
+        if "No files returned from query parse" in resp['error']['message']:
+            raise SymbolsError(resp['error']['message'])
 
         raise Exception('{}:\n{}'.format(
             resp['error']['message'],

--- a/tests/test_jsonrpc.py
+++ b/tests/test_jsonrpc.py
@@ -1,4 +1,6 @@
 from pymarketstore import jsonrpc
+from pymarketstore.exceptions import SymbolsError
+
 import pytest
 try:
     from unittest.mock import patch
@@ -28,4 +30,11 @@ def test_jsonrpc(requests):
         'data': 'something',
     }
     with pytest.raises(Exception):
+        cli.response(resp)
+
+    resp['error'] = {
+        'message': 'No files returned from query parse',
+        'data': 'something',
+    }
+    with pytest.raises(SymbolsError):
         cli.response(resp)

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -1,6 +1,7 @@
 from ast import literal_eval
-from pymarketstore import results
 import imp
+
+from pymarketstore import results
 imp.reload(results)
 
 


### PR DESCRIPTION
# Summary
- Raise a verbose error when symbols are not found
- operate without  calling mkts a second time, just matching queried symbols and returned ones.
- the case where no symbol exists at all and where some symbols exists is a bit different
- also the SymbolsErrors inherits from KeyError which is debatable

# Examples

## For all symbols missing
- before
```
param = pymkts.Params("NON_SYMBOL",
                      '1H',
                      'OHLCV',
                      # start=pd.Timestamp("2013-05-01"),
                      # end=pd.Timestamp("2018-05-23"),
                      # limit=1000
                      )

df = client.query(param).first().df()
"""
root@49e73560b653:/project# python dockerfiles/marketstore_v2/client.py
Traceback (most recent call last):
  File "dockerfiles/marketstore_v2/client.py", line 16, in <module>
    df = client.query(param).first().df()
  File "/opt/anaconda/lib/python2.7/site-packages/pymarketstore/client.py", line 93, in query
    reply = self._request('DataService.Query', **query)
  File "/opt/anaconda/lib/python2.7/site-packages/pymarketstore/client.py", line 84, in _request
    return self.rpc.response(rpc_reply)
  File "/opt/anaconda/lib/python2.7/site-packages/pymarketstore/jsonrpc.py", line 48, in response
    str(resp['error'].get('data', ''))))
Exception: No files returned from query parse:
None
root@49e73560
"""
```
- after
```
raise SymbolsError(NON_SYMBOL missing)
```

## For some (not all) symbols missing
- before
```
if passing multiple symbols no errors will be raised -> we need to be proactive in that case... will add somewhat minimal latency?
we can make synchronous calls or fail in the query method
param = pymkts.Params(["NON_SYMBOL", 'AAPL'],
                      '1H',
                      'OHLCV',
                      # start=pd.Timestamp("2013-05-01"),
                      # end=pd.Timestamp("2018-05-23"),
                      limit=1000)

df = client.query(param).all()
print(df)
print("END")
exit(1)
"""root@49e73560b653:/project# python dockerfiles/marketstore_v2/client.py
{u'AAPL/1H/OHLCV': DataSet(key=AAPL/1H/OHLCV, shape=(1000,), dtype=[('Epoch', '<i8'), ('Open', '<f4'), ('High', '<f4'), ('Low', '<f4'), ('Close', '<f4'), ('Volume', '<i4')])}
END
"""
```

- after

```
raise SymbolsError(NON_SYMBOL missing)
```

This is a little bit experimental, so would prefer a review but would ultimately be useful.

